### PR TITLE
Fix behavior of getSavedCircuitState when not in Runestone environment

### DIFF
--- a/source/widget.js
+++ b/source/widget.js
@@ -646,12 +646,17 @@ const createStudentEditor = ({
  * @returns circuit in string form, else undefined
  */
 const getSavedCircuitState = async () => {
-  let previousState = await SPLICE.getState();
-  console.log("Restoring saved circuit state.");
-  if (previousState) {
-    previousState = previousState.circuit;
+  try {
+    let previousState = await SPLICE.getState();
+    console.log("Restoring saved circuit state.");
+    if (previousState) {
+      previousState = previousState.circuit;
+    }
+    return previousState;
+  } catch (err) {
+    console.log("Could not get saved circuit state:", err);
+    return undefined;
   }
-  return previousState;
 }
 
 // MARK: - widget creation functions


### PR DESCRIPTION
When developing the textbook locally in PreTeXt, there is no saved circuit state to fetch from the backend. This change quickly times out checking for the state, which loads the widget even without a backend.

This is (hopefully) a temporary fix—ideally, we are able to figure out that there is no Runestone backend and just load the widget immediately instead of handling the timeout.